### PR TITLE
fixed jumping readmore

### DIFF
--- a/components/AnimeContent.js
+++ b/components/AnimeContent.js
@@ -9,7 +9,7 @@ const AnimeContent = ({ children, columns, rows }) => {
           div {
             display: grid;
             grid-template-columns: minmax(0, 1fr) 250px 700px minmax(0, 1fr);
-            grid-template-rows: 150px auto auto auto auto;
+            grid-template-rows: 150px 80px auto auto auto;
             max-width: 100vw;
           }
 

--- a/components/AnimeHeader.js
+++ b/components/AnimeHeader.js
@@ -8,11 +8,13 @@ const animeHeader = props => {
 
   let ConditionalLink = ({ children }) => {
     return props.router.pathname === "/" ? (
-      <Link as={`/anime/${props.data.id}`} href={`/post?id=${props.data.id}`}>
-        <a aria-label="Read more about the biggest trending anime">
-          {children}
-        </a>
-      </Link>
+      <Fragment>
+        <Link as={`/anime/${props.data.id}`} href={`/post?id=${props.data.id}`}>
+          <a aria-label="Read more about the biggest trending anime">
+            {children}
+          </a>
+        </Link>
+      </Fragment>
     ) : (
       children
     );
@@ -81,7 +83,7 @@ const animeHeader = props => {
             width: 25%;
             width: 210px;
             grid-column: 2/3;
-            grid-row: 2/4;
+            grid-row: 2/5;
           }
           .cover img {
             width: 100%;
@@ -90,21 +92,18 @@ const animeHeader = props => {
             border-radius: 5px;
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
           }
-           {
-            /* .description {
-            grid-row: 2/3;
-            grid-column: 3/4;
-            margin-top: -220px;
-            --gradient-background: linear-gradient(
-              to top,
-              #1f202c 20%,
-              rgba(31, 32, 44, 0)
-            );
-          } */
+          .cover a img {
+            margin-top: -10px;
+          }
+          :global(a > img) {
+            margin-top: -10px;
           }
           h1 {
             margin-top: 0px;
             margin-bottom: 0px;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
           }
           h2 {
             margin-top: 8px;
@@ -113,12 +112,15 @@ const animeHeader = props => {
           h3 {
             margin: 0;
             margin-bottom: 6px;
+            position: absolute;
+            top: -26px;
           }
           p {
             margin-top: 8px;
             width: 60%;
           }
           .titles {
+            position: relative;
             grid-column: 3/4;
             grid-row: 2/3;
           }

--- a/components/ReadMore.js
+++ b/components/ReadMore.js
@@ -37,7 +37,7 @@ const ReadMore = props => {
           height: 70px;
         }
         .expand {
-          height: 100%;
+          height: auto;
         }
         .expand:after {
           background: linear-gradient(

--- a/pages/post.js
+++ b/pages/post.js
@@ -20,12 +20,6 @@ const Post = ({ header, episodes, characters }) => {
           <div label="Characters">
             <CharacterList data={characters} />
           </div>
-          <div label="Croc">
-            After 'while, <em>Crocodile</em>!
-          </div>
-          <div label="Sarcosuchus">
-            Nothing to see here, this tab is <em>extinct</em>!
-          </div>
         </Tabs>
       </AnimeContent>
     </Layout>


### PR DESCRIPTION
the readmore component now doesnt jump on desktop. The height being changed to auto made the biggest difference since being a 100% just filled the height of the row, being auto extends the height of the row instead. The trending title on the homepage has now been absolutely positioned to allow a fixed height row. Used a global css attribute to access a child components elements (bit of a workaround since using styled-jsx). 