### PR TITLE
feat(fix): include additional spacing & underline active tab

### DIFF
--- a/components/AnimeCategories.js
+++ b/components/AnimeCategories.js
@@ -79,7 +79,7 @@ const AnimeCategories = ({ data }) => (
         left: 0;
         bottom: -13px;
         z-index: 2;
-        padding-left: 30px;
+        padding: 15px;
         margin: 0;
       }
       .animelist {

--- a/components/AnimeContent.js
+++ b/components/AnimeContent.js
@@ -15,7 +15,7 @@ const AnimeContent = ({ children, columns, rows }) => {
 
           @media (max-width: 768px) {
             div {
-              grid-template-columns: 6px 1.4fr 1fr 6px;
+              grid-template-columns: 15px 1.4fr 1fr 15px;
               grid-template-rows: 150px auto auto auto auto;
             }
           }

--- a/components/CharacterList.js
+++ b/components/CharacterList.js
@@ -24,15 +24,14 @@ const CharacterList = ({ data }) => {
           </div>
         ))
       ) : (
-        <div className="character">
-          <p>no data available</p>
-        </div>
-      )}
+          <div className="character">
+            <p>no data available</p>
+          </div>
+        )}
       <style jsx>
         {`
           .character {
             display: grid;
-            grid-template-columns: 18px 120px auto 18px;
             grid-gap: 15px;
             padding-bottom: 40px;
           }

--- a/components/CharacterList.js
+++ b/components/CharacterList.js
@@ -24,14 +24,15 @@ const CharacterList = ({ data }) => {
           </div>
         ))
       ) : (
-          <div className="character">
-            <p>no data available</p>
-          </div>
-        )}
+        <div className="character">
+          <p>no data available</p>
+        </div>
+      )}
       <style jsx>
         {`
           .character {
             display: grid;
+            grid-template-columns: 18px 120px auto 18px;
             grid-gap: 15px;
             padding-bottom: 40px;
           }

--- a/components/EpisodeList.js
+++ b/components/EpisodeList.js
@@ -53,7 +53,7 @@ const EpisodeList = ({ data }) => {
           @media (max-width: 768px) {
             .episode {
               grid-template-columns: 50px 3fr 5fr;
-              padding-bottom: 20px;
+              padding: 0 5px 20px 0;
             }
           }
         `}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -4,7 +4,7 @@ import Header from "./Header";
 const Layout = props => (
   <div>
     <Head>
-      <title>My page title</title>
+      <title>AnimeBeast</title>
       <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       <meta
         name="Description"

--- a/components/Tab.js
+++ b/components/Tab.js
@@ -3,16 +3,18 @@ import React from "react";
 const Tab = props => {
   const { label, activeTab } = props;
 
-  let onClick = () => {
+  let onClick = event => {
     const { label, onClick } = props;
-    onClick(label);
+    onClick(label, event.target);
   };
 
-  let isActive = activeTab === label && "tab-list-active"
+  let isActive = activeTab === label && "tab-list-active";
 
   return (
-    <li className="tab-list-item" onClick={onClick}>
-      <div className={isActive}>{label}</div>
+    <li className="tab-list-item">
+      <div className={isActive} onClick={onClick}>
+        {label}
+      </div>
       <style jsx>
         {`
           .tab-list-item {
@@ -23,10 +25,6 @@ const Tab = props => {
             padding: 0.5rem 0.75rem;
             cursor: pointer;
             border-radius: 3px 3px 0 0;
-          }
-          .tab-list-active {
-            padding-bottom: 6px;
-            border-bottom: 2px solid white;
           }
         `}
       </style>

--- a/components/Tab.js
+++ b/components/Tab.js
@@ -8,18 +8,15 @@ const Tab = props => {
     onClick(label);
   };
 
-  let className = "tab-list-item";
-
-  if (activeTab === label) {
-    className += " tab-list-active";
-  }
+  let isActive = activeTab === label && "tab-list-active"
 
   return (
-    <li className={className} onClick={onClick}>
-      {label}
+    <li className="tab-list-item" onClick={onClick}>
+      <div className={isActive}>{label}</div>
       <style jsx>
         {`
           .tab-list-item {
+            text-align: center;
             display: inline-block;
             list-style: none;
             margin-bottom: -1px;
@@ -27,14 +24,9 @@ const Tab = props => {
             cursor: pointer;
             border-radius: 3px 3px 0 0;
           }
-
           .tab-list-active {
-             {
-              /* border: solid #ccc; */
-            }
-             {
-              /* border-width: 1px 1px 0 1px; */
-            }
+            padding-bottom: 6px;
+            border-bottom: 2px solid white;
           }
         `}
       </style>

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -71,6 +71,7 @@ const Tabs = props => {
               margin-top: 40px;
             }
             .tab-list {
+              grid-column: 2/4;
               top: 0px;
             }
           }

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import shortid from "shortid";
 import Tab from "../components/Tab";
 
@@ -8,13 +8,20 @@ const Tabs = props => {
   // Declare a new state variable, which we'll call "count"
   const [activeTab, setActiveTab] = useState(props.children[0].props.label);
 
-  let onClickTabItem = tab => {
+  const underline = useRef(null);
+
+  let onClickTabItem = (tab, element) => {
+    let left = element.offsetLeft;
+    let width = element.offsetWidth;
+    underline.current.style.setProperty("--left-position", `${left}px`);
+    underline.current.style.setProperty("--line-width", `${width}px`);
     setActiveTab(tab);
   };
 
   return (
     <div className="tabs">
       <ol className="tab-list">
+        <div className="underline" ref={underline} />
         {children.map(child => {
           const key = shortid.generate();
           const { label } = child.props;
@@ -41,9 +48,9 @@ const Tabs = props => {
             grid-column: 3/4;
             background: #19191f;
             border-radius: 5px 5px 0 0;
-
             top: 10px;
             margin-top: 30px;
+            position: relative;
           }
           .tab-list {
             background: #19191f;
@@ -63,6 +70,17 @@ const Tabs = props => {
             top: -10px;
             height: 10px;
             background: #1f202c;
+          }
+          .underline {
+            --left-position: 16px;
+            --line-width: 66px;
+            position: absolute;
+            left: var(--left-position);
+            bottom: 0;
+            height: 2px;
+            width: var(--line-width);
+            background: #ffffff;
+            transition: left ease 100ms, width ease-in-out 100ms;
           }
           @media (max-width: 768px) {
             .tabs {

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,4 +1,4 @@
-import Layout from "../components/MyLayout"
+import Layout from "../components/Layout"
 
 const About = () => (
   <Layout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import Layout from "../components/MyLayout.js";
+import Layout from "../components/Layout";
 import axios from "axios";
 
 import AnimeContent from "../components/AnimeContent";
@@ -16,7 +16,7 @@ export default function Index({ header, data }) {
   );
 }
 
-Index.getInitialProps = async function() {
+Index.getInitialProps = async function () {
   let obj = {
     comedy: 160,
     action: 150,
@@ -30,7 +30,7 @@ Index.getInitialProps = async function() {
   let promiseArray = Object.keys(obj).map(x =>
     axios.get(
       `https://kitsu.io/api/edge/trending/anime?limit=15&in_category=true&category=${
-        obj[x]
+      obj[x]
       }`
     )
   );

--- a/pages/post.js
+++ b/pages/post.js
@@ -1,4 +1,4 @@
-import Layout from "../components/MyLayout.js";
+import Layout from "../components/Layout";
 import axios from "axios";
 
 import AnimeHeader from "../components/AnimeHeader.js";
@@ -26,7 +26,7 @@ const Post = ({ header, episodes, characters }) => {
   );
 };
 
-Post.getInitialProps = async function(context) {
+Post.getInitialProps = async function (context) {
   const { id } = context.query;
 
   async function getTrendingHeader() {


### PR DESCRIPTION
CSS-in-JS Changes:
---
### Mobile
**1) Spacing on sides of phone by 15px (or to make it look like it coinsides with 15px)**
![Screenshot 2019-04-02 at 11 37 07 pm](https://user-images.githubusercontent.com/26009168/55440668-5292ee00-55a0-11e9-9bb3-84e10b1e2819.png)
<br>
![Screenshot 2019-04-02 at 11 37 16 pm](https://user-images.githubusercontent.com/26009168/55440670-54f54800-55a0-11e9-9fd4-407697e5e1e8.png)

**2) Underline Tabs (on active)**
![Screenshot 2019-04-02 at 11 31 50 pm](https://user-images.githubusercontent.com/26009168/55440457-95a09180-559f-11e9-89dc-b8fb22a5c099.png)


**3) Page Title changed to it's proper value
![Screenshot 2019-04-02 at 11 33 48 pm](https://user-images.githubusercontent.com/26009168/55440534-dac4c380-559f-11e9-889d-714f36cfb8cc.png)
