### PR TITLE
fixed default component on mobile

### DIFF
--- a/components/DefaultReviewStat.js
+++ b/components/DefaultReviewStat.js
@@ -28,6 +28,12 @@ const DefaultReviewStat = ({ component }) => {
           p {
             margin: 0px;
           }
+          @media (max-width: 767px) {
+            .default {
+              grid-column: 1/3;
+              padding: 10px 20px;
+            }
+          }
         `}
       </style>
     </div>


### PR DESCRIPTION
Spacing is now fixed for the default component on mobile. It was a simple case of adding some padding and altering the grid-column value